### PR TITLE
fix: resolve build issues

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".scenes.MainActivity"
             android:launchMode="singleTask"
-            android:theme="@style/AppTheme.Main">
+            android:theme="@style/AppTheme.Main"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/hallow/interview/ui/DayView.kt
+++ b/app/src/main/java/com/hallow/interview/ui/DayView.kt
@@ -69,6 +69,7 @@ class DayView(context: Context, attrs: AttributeSet? = null, defStyle: Int = -1)
             Day.StreakPart.START -> fillRect(canvas, width.toFloat() / 2, width.toFloat(), fillColor, paint)
             Day.StreakPart.MIDDLE -> fillRect(canvas, 0f, width.toFloat(), fillColor, paint)
             Day.StreakPart.END -> fillRect(canvas, 0f, width.toFloat() / 2, fillColor, paint)
+            null -> {}
         }
         if (isToday) {
             fillCircleStrokeBorder(


### PR DESCRIPTION
## Changelog

- Fixes issue where build was failing due to `android:exported="true"` error being missing

> Manifest merger failed : android:exported needs to be explicitly specified for element <activity#com.hallow.interview.scenes.MainActivity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.

- Fixes issue where app would not compile due to missing null case for `StreakPart`

> e: file:///.../DayView.kt:68:9 'when' expression must be exhaustive, add necessary 'null' branch or 'else' branch instead